### PR TITLE
Fixes defect where secrets README got encrypted

### DIFF
--- a/bin/secrets
+++ b/bin/secrets
@@ -16,7 +16,7 @@ def init():
 def encrypt():
     for file in os.listdir(secrets_dir):
         path = os.path.join(secrets_dir, file)
-        if os.path.isfile(path) and not file.endswith(".enc"):
+        if os.path.isfile(path) and not file.endswith(".enc") and not file == "README.md":
             encrypted = open("{}.enc".format(path), "wb+")
             subprocess.run(["keybase", "pgp", "encrypt", "-i", path], stdout=encrypted)
 


### PR DESCRIPTION
TL;DR
-----

Updates the `secrets` script to ignore the README

Details
-------

Fixes a defect where the `secrets` script would encrypt not only
the secret files in the `secrets` directory but also the README
that explained how everyting worked.
