### PR TITLE
Allows for finer-grained control of secrets

### DIFF
--- a/bin/secrets
+++ b/bin/secrets
@@ -3,31 +3,65 @@
 import os
 import subprocess
 import typer
+from pathlib import Path
+from typing import Optional, List
 
 app = typer.Typer()
 secrets_dir = os.environ.get("SECRETS_DIR")
 
 @app.command()
-def init():
-    if not os.path.exists(secrets_dir):
-        os.mkdir(secrets_dir)
+def encrypt(
+    name: Optional[List[str]] = typer.Argument(None, help="The files within SECRETS_DIR to encrypt"),
+    path: Path = typer.Option(None, "--secrets-directory", "-d", envvar='SECRETS_DIR', help="Directory containing the encrypted secrets"),
+    all: bool = typer.Option(False, help="Encrypt all files in SECRETS_DIR")
+):
+    """
+    Encrypt a file containing secrets
+    """
+    __validate_path(path)
+    files = []
+    if all:
+        for file in path.iterdir():
+            files.append(file)
+    else:
+        for filename in name:
+            files.append(path.joinpath(filename))
+
+    for file in files:
+        if os.path.isfile(file) and not file.name.endswith(".enc") and not file.name == "README.md":
+            print(file)
+            encrypted = open("{}.enc".format(file), "wb+")
+            subprocess.run(["keybase", "pgp", "encrypt", "-i", file], stdout=encrypted)
 
 @app.command()
-def encrypt():
-    for file in os.listdir(secrets_dir):
-        path = os.path.join(secrets_dir, file)
-        if os.path.isfile(path) and not file.endswith(".enc") and not file == "README.md":
-            encrypted = open("{}.enc".format(path), "wb+")
-            subprocess.run(["keybase", "pgp", "encrypt", "-i", path], stdout=encrypted)
+def decrypt(
+    name: Optional[List[str]] = typer.Argument(None, help="The files within SECRETS_DIR to encrypt"),
+    path: Path = typer.Option(None, "--secrets-directory", "-d", envvar='SECRETS_DIR', help="Directory containing the encrypted secrets"),
+    all: bool = typer.Option(False, help="Decrypt all files in SECRETS_DIR")
+):
+    """
+    Decrypt a file containing secrets
+    """
+    __validate_path(path)
+    files = []
+    if all:
+        for file in path.glob('*.enc'):
+            files.append(file)
+    else:
+        for filename in name:
+            files.append(path.joinpath(filename + ".enc"))
 
-@app.command()
-def decrypt():
-    for file in os.listdir(secrets_dir):
-        path = os.path.join(secrets_dir, file)
-        if os.path.isfile(path) and file.endswith(".enc"):
-            decrypted = open(path[0:-4], "wb+")
-            subprocess.run(["keybase", "pgp", "decrypt", "-i", path], stdout=decrypted )
+    for file in files:
+        if os.path.isfile(file) and file.name.endswith(".enc"):
+            print(file)
+            decrypted = open(path.joinpath(file.name[0:-4]), "wb+")
+            subprocess.run(["keybase", "pgp", "decrypt", "-i", file], stdout=decrypted )
 
+def __validate_path(path: Path):
+    if not path.is_dir() or not path.exists():
+        typer.echo("PATH is not a directory")
+        raise typer.Exit(code=1)
+    
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
TL;DR
-----

Updates `secrets` scripts so it's no longer all or nothing

Details
-------

After working with the `secrets` script for a bit it's become
apparent that the all-or-nothing approach was easy but not ideal.
The primary challenge is that encrypting a changex secret re-
encrypted all secrets which created a spurious change for all of
the other secrets.

This change changes the default mode to encrypting/decrypting a
specific secret file vs. all. This will avoid the spurious changes
and show a truer histroy of secret change.

It's still possible to use the previous behavior by specifying
the `--all` flag.
