### PR TITLE
Supports diff for secrets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.enc diff=secrets

--- a/bin/secrets
+++ b/bin/secrets
@@ -57,6 +57,19 @@ def decrypt(
             decrypted = open(path.joinpath(file.name[0:-4]), "wb+")
             subprocess.run(["keybase", "pgp", "decrypt", "-i", file], stdout=decrypted )
 
+@app.command()
+def diff(
+    name: Optional[List[str]] = typer.Argument(None, help="The files within SECRETS_DIR to diff")
+):
+    """
+    Decrypt a file containing secrets
+    """
+    files = []
+
+    for file in name:
+        if os.path.isfile(file) and os.path.basename(file).endswith(".enc"):
+            subprocess.run(["keybase", "pgp", "decrypt", "-i", file])
+
 def __validate_path(path: Path):
     if not path.is_dir() or not path.exists():
         typer.echo("PATH is not a directory")


### PR DESCRIPTION
TL;DR
-----

Adds a custom diff filter for encrypted secrets

Details
-------

Adds a `diff` subcommand to the `secrets` script to support diff
on an encrypted secrets file, then uses that subcommand to allow
`git diff` to work on secrets.
